### PR TITLE
Admin user autocomplete

### DIFF
--- a/action.php
+++ b/action.php
@@ -18,7 +18,7 @@ class action_plugin_acknowledge extends ActionPlugin
     public function register(EventHandler $controller)
     {
         $controller->register_hook('COMMON_WIKIPAGE_SAVE', 'AFTER', $this, 'handlePageSave');
-        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handleAjaxAssign');
+        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handleAjaxAcknowledge');
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handleAjaxAutocomplete');
         $controller->register_hook('PLUGIN_SQLITE_DATABASE_UPGRADE', 'AFTER', $this, 'handleUpgrade');
     }
@@ -58,9 +58,9 @@ class action_plugin_acknowledge extends ActionPlugin
      * @param Event $event
      * @param $param
      */
-    public function handleAjaxAssign(Event $event, $param)
+    public function handleAjaxAcknowledge(Event $event, $param)
     {
-        if ($event->data === 'plugin_acknowledge_assign') {
+        if ($event->data === 'plugin_acknowledge_acknowledge') {
             $event->stopPropagation();
             $event->preventDefault();
 
@@ -80,7 +80,6 @@ class action_plugin_acknowledge extends ActionPlugin
     public function handleAjaxAutocomplete(Event $event)
     {
         if ($event->data === 'plugin_acknowledge_autocomplete') {
-
             if (!checkSecurityToken()) return;
 
             global $INPUT;

--- a/admin/report.php
+++ b/admin/report.php
@@ -122,9 +122,11 @@ class admin_plugin_acknowledge_report extends AdminPlugin
         echo $this->homeLink();
 
         $form = new Form(['method' => 'GET']);
+        $form->id('acknowledge__user-autocomplete');
         $form->setHiddenField('do', 'admin');
         $form->setHiddenField('page', 'acknowledge_report');
-        $form->addTextInput('user', $this->getLang('overviewUser'));
+        $form->addTextInput('user', $this->getLang('overviewUser'))
+            ->attr('type', 'search');
         $form->addButton('', '>');
         echo $form->toHTML();
 

--- a/helper.php
+++ b/helper.php
@@ -123,6 +123,7 @@ class helper_plugin_acknowledge extends Plugin
     }
 
     /**
+     * Returns all users, formatted for autocomplete
      *
      * @return array
      */
@@ -135,11 +136,11 @@ class helper_plugin_acknowledge extends Plugin
             return [];
         }
 
-        $cb = function($k, $v) {
-          return [
+        $cb = function ($k, $v) {
+            return [
               'value' => $k,
               'label' => $k  . ' (' . $v['name'] . ')'
-          ];
+            ];
         };
         $users = $auth->retrieveUsers();
         $users = array_map($cb, array_keys($users), array_values($users));

--- a/helper.php
+++ b/helper.php
@@ -122,6 +122,31 @@ class helper_plugin_acknowledge extends Plugin
         return false;
     }
 
+    /**
+     *
+     * @return array
+     */
+    public function getUsers()
+    {
+        /** @var AuthPlugin $auth */
+        global $auth;
+
+        if (!$auth->canDo('getUsers')) {
+            return [];
+        }
+
+        $cb = function($k, $v) {
+          return [
+              'value' => $k,
+              'label' => $k  . ' (' . $v['name'] . ')'
+          ];
+        };
+        $users = $auth->retrieveUsers();
+        $users = array_map($cb, array_keys($users), array_values($users));
+
+        return $users;
+    }
+
     // endregion
     // region Page Data
 

--- a/script.js
+++ b/script.js
@@ -1,5 +1,31 @@
 jQuery(function () {
 
+    /**
+     * admin interface: autocomplete users
+     */
+    function adminAutocomplete($form) {
+
+        $form.find('input')
+            .autocomplete({
+                source: function (request, response) {
+                    jQuery.getJSON(DOKU_BASE + 'lib/exe/ajax.php?call=plugin_acknowledge_autocomplete', {
+                        user: request.term,
+                        sectok: $form.find('input[name="sectok"]').val()
+                    }, response);
+                },
+                minLength: 0
+            });
+    }
+
+    const $form = jQuery('.dokuwiki.mode_admin div.plugin_acknowledgement_admin form#acknowledge__user-autocomplete');
+    if ($form.length) {
+        adminAutocomplete($form);
+    }
+
+    /*
+     * Handle assignments
+     */
+
     let $aContainer = jQuery('.plugin-acknowledge-assign');
 
     // if no container is found, create one in the last section

--- a/script.js
+++ b/script.js
@@ -13,7 +13,7 @@ jQuery(function () {
                         sectok: $form.find('input[name="sectok"]').val()
                     }, response);
                 },
-                minLength: 0
+                minLength: 1
             });
     }
 

--- a/script.js
+++ b/script.js
@@ -39,19 +39,19 @@ jQuery(function () {
         if (section.length === 0) {
             return;
         }
-        $aContainer = jQuery('<div class="plugin-acknowledge-assign"></div>');
+        $aContainer = jQuery('<div class="plugin-acknowledge-banner"></div>');
         section.append($aContainer);
     }
 
     $aContainer.on('submit', function (event) {
         event.preventDefault();
-        var $form = jQuery(event.target),
+        const $form = jQuery(event.target),
             ack = $form.find("input[name='ack']")[0];
 
         $aContainer.load(
             DOKU_BASE + "lib/exe/ajax.php",
             {
-                call: "plugin_acknowledge_assign",
+                call: "plugin_acknowledge_acknowledge",
                 id: JSINFO.id,
                 ack: ack.checked === true ? 1 : 0
             }
@@ -60,12 +60,12 @@ jQuery(function () {
     $aContainer.load(
         DOKU_BASE + 'lib/exe/ajax.php',
         {
-            call: 'plugin_acknowledge_assign',
+            call: 'plugin_acknowledge_acknowledge',
             id: JSINFO.id
         },
         response => {
             // remove container if no data to show
-            if(response === '') {
+            if (response === '') {
                 $aContainer.remove();
             }
         }

--- a/style.less
+++ b/style.less
@@ -16,7 +16,7 @@
     }
 }
 
-.plugin-acknowledge-assign {
+.plugin-acknowledge-banner {
     @check-ok-color: #355723;
     @check-needed-color: #840705;
 

--- a/syntax/assign.php
+++ b/syntax/assign.php
@@ -59,7 +59,7 @@ class syntax_plugin_acknowledge_assign extends SyntaxPlugin
         }
 
         // a canvas to render the output to
-        $renderer->doc .= '<div class="plugin-acknowledge-assign">…</div>';
+        $renderer->doc .= '<div class="plugin-acknowledge-banner">…</div>';
         return true;
     }
 }


### PR DESCRIPTION
Adds autocomplete to user field in admin interface.

Currently the autocomplete looks up all users, it might be better to show only users that are relevant for acknowledgements.

The current search is technically easier and the only downside for the user / admin, as far as I can see, is that they might get a long list of users and they have to type additional characters to limit the results.

Looking up only relevant users may be more resource intensive, though.